### PR TITLE
making the default method with no parameters supplied be a single type

### DIFF
--- a/R/keypoints.R
+++ b/R/keypoints.R
@@ -49,7 +49,7 @@ ocv_keypoints_options <- function(method = c("FAST", "Harris"), ...){
   method <- match.arg(method)
   ldots <- list(...)
   if(method == "FAST"){
-    params <- list(threshold = 0, nonmaxSuppression = TRUE, type = c("TYPE_9_16", "TYPE_7_12", "TYPE_5_8"))
+    params <- list(threshold = 0, nonmaxSuppression = TRUE, type = "TYPE_5_8")
   }else if(method == "Harris"){
     params <- list(numOctaves = 6, corn_thresh = 0.01, DOG_thresh = 0.01, maxCorners = 5000, num_layers = 4)
   }


### PR DESCRIPTION
If you don't specify the method when calling `ocv_keypoints`, it currently fails because there are multiple inputs to the switch statement

```r
# this generates an error, when it really shouldn't
mona <- ocv_read('https://jeroen.github.io/images/monalisa.jpg')
mona <- ocv_resize(mona, width = 320, height = 477)
pts <- ocv_keypoints(mona, method = "FAST")
```
